### PR TITLE
Moved exporter to separate solution repo

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -148,11 +148,10 @@ versions:
   ## for Prometheus Exporter ##
 
   - dir: 'exporter'
-    repo: postgresql9
+    repo: postgresql-exporter
     templateSubDir: exporter
     tags:
-      - 'exporter'
-      - 'exporter-0.8.0'
+      - '0.8.0'
     from: *from9
     packages:
       postgres_exporter:

--- a/versions.yaml
+++ b/versions.yaml
@@ -148,7 +148,7 @@ versions:
   ## for Prometheus Exporter ##
 
   - dir: 'exporter'
-    repo: postgresql-exporter
+    repo: postgresql-exporter0
     templateSubDir: exporter
     tags:
       - '0.8.0'


### PR DESCRIPTION
Moved exporter from PostgreSQL9 to separate solution repo and changed tags accordingly, to be able to use in applications based on all PostgreSQL versions (9, 10, 11).